### PR TITLE
Errors listing accounts with a profile set, instead of crashing

### DIFF
--- a/project/main.py
+++ b/project/main.py
@@ -17,7 +17,8 @@ def update_access_key(key):
 def set_DryRun(bool):
     values.DryRun = bool
 
-def readConfigFile(path,logging):
+
+def readConfigFile(path):
     configMap = []
     try:
         logging.debug("Config file path %s" % path)
@@ -62,7 +63,7 @@ def main():
     rootLogger.addHandler(fileHandler)
     rootLogger.addHandler(consoleHandler)
 
-    configMap = readConfigFile(args.config,logging)
+    configMap = readConfigFile(args.config)
 
     # args.dryRun = True
     username = args.user

--- a/project/plugins/ec2.py
+++ b/project/plugins/ec2.py
@@ -3,7 +3,6 @@ import pprint
 import boto3
 import time
 from project import values
-from project.plugins.iam import get_iam_session
 
 
 def get_ec2_client(configMap, **key_args):
@@ -79,7 +78,6 @@ def terminate_instances(configMap, username,  **key_args):
 
     elb_client = get_elb_client(configMap, **key_args)
 
-
     instance_names = key_args.get('instances')
 
     for instance_name in instance_names:
@@ -124,7 +122,8 @@ def terminate_instances(configMap, username,  **key_args):
                         time.sleep(45)
     pass
 
-def get_loadbalancername(configMap,instance_name,client, **key_args):
+
+def get_loadbalancername(configMap, instance_name, client, **key_args):
 
     response = client.describe_load_balancers()
 
@@ -136,6 +135,7 @@ def get_loadbalancername(configMap,instance_name,client, **key_args):
         for tag in tags:
             if tag.get('Value') == instance_name:
                 return loadbalancer.get('LoadBalancerName')
+
 
 def _remove_instance_from_loadbalancer(elb_client, elb_name, instance_id):
     response = elb_client.deregister_instances_from_load_balancer(

--- a/project/plugins/parameter_store.py
+++ b/project/plugins/parameter_store.py
@@ -45,6 +45,7 @@ def set_param_in_region(configMap,region, parameter, value, value_is_file=False,
         sys.exit(1)
     if values.DryRun is True:
         logging.info('Dry run of put_parameter')
+        result = {}
     else:
         if description:
             if key:
@@ -80,7 +81,7 @@ def set_param_in_region(configMap,region, parameter, value, value_is_file=False,
     return return_value
 
 
-def set_paramameter(configMap,region_list, param_name, value, value_is_file=False, description=None, encrypt=False, key=None):
+def set_paramameter(configMap, region_list, param_name, value, value_is_file=False, description=None, encrypt=False, key=None):
     result = {}
     for region in region_list:
         logging.debug("Checking region: " + region)

--- a/project/plugins/ssh.py
+++ b/project/plugins/ssh.py
@@ -1,4 +1,3 @@
-import json
 import logging
 import paramiko
 import re
@@ -62,7 +61,7 @@ def SSH_server(hostname, username, port, commands, password=None, pkey=None, mar
                 logging.info('Dry run, '+hostname+'| ssh command: '+command)
             else:
                 try:
-                    # logging.info('Running command: %s' % str(command))
+                    logging.debug('Running command: %s' % str(command))
                     stdin, stdout, stderr = client.exec_command(command,  get_pty=True)
                     stdout.read()
                     error = stderr.read()

--- a/project/values.py
+++ b/project/values.py
@@ -3,4 +3,3 @@ user_password = ('','')
 hide_key = False
 DryRun = False
 profile = None
-


### PR DESCRIPTION
In the config file if a user had an "credential_profile" set under get_new_key, the list function would not handle this, and crash.
Now it throws a not found error and carries on.

Other small bug fixes as well.