### PR TITLE
Update Azure Pipelines service connections

### DIFF
--- a/project/config/requirements.txt
+++ b/project/config/requirements.txt
@@ -1,7 +1,9 @@
-azure-keyvault
-azure-mgmt-resource
+azure-devops
 azure-identity
+azure-keyvault
 azure-mgmt-common
+azure-mgmt-resource
+azure-mgmt-compute
 pytz>=2018.7
 jenkinsapi>=0.3.8
 requests>=2.20.1


### PR DESCRIPTION
Add new update_pipeline_service_connection method in the azure plugin for update service connections in azure pipelines

This requires the changes to the config used.

For the user that azure pipelines is using to communicate with AWS, need to add the following under the azure plugin:

```
              - update_pipeline_service_connection:
                    devops_organization_url: 'https://dev.azure.com/<organization_name>'
                    projects:
                        <project_name_01>:
                            - '<endpoint_id>' # <endpoint_name>
                        <project_name_02>:
                            - '<endpoint_id>' # <endpoint_name>

```
In addition, under the Global section of the config, you will need to add a "personal_access_token" under "azure_credentials", eg:

```
  azure_credentials:
      personal_access_token: '<pat_value>'
      prod:
          client_id: '<client_id_value>'
          secret:  '<secret>'
          tenant: '<tenant_id>'
      dev:
          client_id: '<client_id>'
          secret: '<secret>'
          tenant: '<tenant_id>'

```