### PR TITLE
Fix Azure VM operations to use unwrapped credentials

### DIFF
--- a/project/plugins/azure.py
+++ b/project/plugins/azure.py
@@ -31,7 +31,7 @@ def rotate_autoscalers_cloud(configMap, username,  **key_args):
                 resource_group_name = resource_group
                 sub_id = item.get(region).get(resource_group)
                 client = ResourceManagementClient(wrapped_credential, sub_id)
-                compute_client = ComputeManagementClient(wrapped_credential, sub_id)
+                compute_client = ComputeManagementClient(credentials, sub_id)
                 resource_groups = client.resources.list_by_resource_group(resource_group_name)
                 for rg in resource_groups:
                     if rg.type == 'Microsoft.Compute/virtualMachines':


### PR DESCRIPTION
The credentials object supports a newer method of authentication required for some services, and the credential wrapper is a measure to authenticate against other services until they support the new method of authentication. VM operations apparently now support the new authentication and the wrapper needs to come off for it to work