### PR TITLE
Just log the exception and carry on

### DIFF
--- a/project/config/requirements.txt
+++ b/project/config/requirements.txt
@@ -28,4 +28,3 @@ google-cloud-storage>=1.33.0
 google-cloud-kms>=2.2.0
 httplib2>=0.18.1
 crcmod>=1.7
-

--- a/project/plugins/ssh.py
+++ b/project/plugins/ssh.py
@@ -103,7 +103,6 @@ def ssh_server(hostname, username, port, commands, password=None, pkey=None, mar
                 execute_command(client, command, password)
     except Exception as e:
         logging.error(f'Error with SSH connection: {e}')
-        raise e
     finally:
         client.close()
 


### PR DESCRIPTION
We aren't handling this exception upstream. So just log the error, and proceed to the next thing.