### PR TITLE
Allow kms key override for store_password_parameter_store

### DIFF
--- a/project/plugins/iam.py
+++ b/project/plugins/iam.py
@@ -302,12 +302,14 @@ def store_password_parameter_store(configMap, username,  **key_args):
     if values.DryRun is True:
         logging.info('Dry run: store_key_parameter_store')
     else:
+        key_id = key_args.get('key', configMap['Global']['parameter_store']['KeyId'])
+
         client.put_parameter(
             Name='LOCK.'+username.upper(),
             Description='modified by LOCK',
             Value='Username: ' + values.user_password[0] + ' Password: ' + values.user_password[1],
             Type='SecureString',
-            KeyId=configMap['Global']['parameter_store']['KeyId'],
+            KeyId=key_id,
             Overwrite=True
         )
         logging.info('      '+username + ' username and password written to parameter store.')


### PR DESCRIPTION
The LOCK run once again failed when trying to update parameter store at the flight-deck-monitoring-smtp user. While the key used by the parameter was changed to the default SSM key following the previous LOCK run, the code was still referencing the global key defined in the config.

This will enable overriding the global kms key id for just the store_password_parameter_store function in the iam plugin.