### PR TITLE
Handle unhealthy Azure VMs

### DIFF
--- a/project/plugins/azure.py
+++ b/project/plugins/azure.py
@@ -44,7 +44,7 @@ def rotate_vms(configMap, username,  **key_args):
                                 result = compute_client.virtual_machines.get(resource_group_name,
                                                                             resource.name,
                                                                             expand='instanceView')
-                                if 'running' in result.instance_view.statuses[1].display_status:
+                                if len (result.instance_view.statuses) > 1 and 'running' in result.instance_view.statuses[1].display_status:
                                     to_rotate.append(result.instance_view.computer_name)
                                 else:
                                     logging.warning(f'{resource.name} Not in RUNNING state - skipping')


### PR DESCRIPTION
This was throwing an error if the instances hadn't started properly.