### PR TITLE
1password plugin, multi-threading, and pre-flight check

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ LOCK has 4 main modes that accept an IAM user as an argument or from a YAML conf
 
 - `list`: Show user keys with: Access Key ID, Status, Create Date, Last Used.
 - `rotate`: Rotates the AWS IAM key and update the key at set locations by running functions sequentially under plugins provided by the config file.
-- `validate`: Checks to see if the new key is being used, if it is delete the old key
+- `validate`: Checks to see if the new key is being used. If it is, delete the old key.
 - `getnewkey`: Rotate the AWS IAM Key
 
 ## Up and Running
@@ -16,10 +16,10 @@ LOCK has 4 main modes that accept an IAM user as an argument or from a YAML conf
 - Clone this repository
 - Run `python3 -m venv .env` to create a virtual environment
 - Run `source .env/bin/activate` to activate the virtual environment
-- Run `python3 -m pip install -r project/config/requirements.txt` to install the dependencies
+- Run `python3 -m pip install -r project/config/requirements.txt` to install the dependencies
 - Run from LOCK's root folder
 
-#
+
 ## Running LOCK from the Command Line
 
 To rotate keys from the command line, use `python3` to run the main script.

--- a/project/main.py
+++ b/project/main.py
@@ -51,9 +51,13 @@ def validate_keys(username, all_users, configMap):
         delete_old_key(user_data, configMap, owner, key, prompt)
 
 
-def rotate_update(config_map, user_data, username, ssh_username=None, ssh_password=None):
+def rotate_update(user_data, config_map, username=None, ssh_username=None, ssh_password=None):
     update_access_key(('', ''))
-    modules = user_data['plugins']
+    if username is None:
+        username = (next(iter(user_data)))
+        modules = user_data[username]['plugins']
+    else:
+        modules = user_data['plugins']
     for plugin in modules:
         my_plugin = importlib.import_module('project.plugins.' + list(plugin.keys())[0])
         plugin = plugin.get(list(plugin.keys())[0])
@@ -76,12 +80,9 @@ def rotate_update(config_map, user_data, username, ssh_username=None, ssh_passwo
 
 def rotate_keys(username, all_users, configMap, user_data, ssh_username, ssh_password):
     if username == 'all':
-        for user_data in all_users:
-            username = (next(iter(user_data)))
-            user_data = user_data.get(username)
-            rotate_update(configMap, user_data, username, ssh_username, ssh_password)
+        utils.run_threads(all_users, rotate_update, configMap, None, ssh_username, ssh_password)
     else:
-        rotate_update(configMap, user_data, username, ssh_username, ssh_password)
+        rotate_update(user_data, configMap, username, ssh_username, ssh_password)
 
 
 def list_keys_for_user(user_data, configMap):

--- a/project/main.py
+++ b/project/main.py
@@ -19,6 +19,74 @@ import yaml
 from project.plugins import iam
 from project.plugins.iam import validate_new_key, get_new_key, create_and_test_key, delete_older_key, get_iam_client
 from project import values
+from project import utils
+
+
+def validate_keys_for_user(userdata, configMap, username):
+    username_to_validate = (next(iter(userdata)))
+    if username != "all" and username != username_to_validate:
+        return
+    user_data = userdata.get(username_to_validate)
+    if user_data.get('plugins'):
+        if user_data.get('plugins')[0].get('iam'):
+            if 'get_new_key' in user_data.get('plugins')[0].get('iam')[0]:
+                validate_new_key(configMap, username_to_validate, user_data)
+            else:
+                logging.info(
+                    f'   No get_new_key section for iam plugin for user {username_to_validate} - skipping')
+        else:
+            logging.info(f'   No iam plugin section for user {username_to_validate} - skipping')
+    else:
+        logging.info(f'   No plugins section for user {username_to_validate} - skipping')
+
+
+def validate_keys(username, all_users, configMap):
+    utils.run_threads(all_users, validate_keys_for_user, configMap, username)
+
+
+def rotate_update(config_map, user_data, username, ssh_username=None, ssh_password=None):
+    update_access_key(('', ''))
+    modules = user_data['plugins']
+    for plugin in modules:
+        my_plugin = importlib.import_module('project.plugins.' + list(plugin.keys())[0])
+        plugin = plugin.get(list(plugin.keys())[0])
+        for method in plugin:  # modules = dict, module = str
+            key_args = (method[list(method.keys())[0]])  # get key pair of method to run
+            if key_args is None:
+                key_args = {}
+            if ssh_username:
+                key_args['ssh_user'] = ssh_username
+            if ssh_password:
+                key_args['ssh_password'] = ssh_password
+            method_to_call = getattr(my_plugin, list(method.keys())[0])  # get method name to run
+            logging.info("Running "+str(method_to_call)[:-15].lstrip('<') + "for " + username)
+            result = method_to_call(config_map, username, **key_args)
+            # TODO: Check result and abort remaining methods if one fails
+            if 'get_new_key' in str(method_to_call) and not result:
+                logging.error(f'Failed to get new key - skipping {username}')
+                return
+
+
+def rotate_keys(username, all_users, configMap, user_data, ssh_username, ssh_password):
+    if username == 'all':
+        for user_data in all_users:
+            username = (next(iter(user_data)))
+            user_data = user_data.get(username)
+            rotate_update(configMap, user_data, username, ssh_username, ssh_password)
+    else:
+        rotate_update(configMap, user_data, username, ssh_username, ssh_password)
+
+
+def list_keys_for_user(user_data, configMap):
+    username = (next(iter(user_data)))
+    iam.list_keys(configMap, username)
+
+
+def list_keys(username, all_users, configMap):
+    if username == 'all':
+        utils.run_threads(all_users, list_keys_for_user, configMap)
+    else:
+        iam.list_keys(configMap, username)
 
 
 def update_access_key(key):
@@ -108,7 +176,7 @@ def main():
         print('DEBUG logging requested')
         log_level = logging.DEBUG
 
-    logFormatter = logging.Formatter('%(asctime)s - %(levelname)s - %(message)s')
+    logFormatter = logging.Formatter('%(asctime)s - %(levelname)s: (tid=%(thread)d) [%(module)s] %(message)s')
     rootLogger = logging.getLogger()
     rootLogger.setLevel(logging.DEBUG)
     consoleHandler = logging.StreamHandler()
@@ -156,6 +224,7 @@ def main():
             ssh_password = input(f"Password for {args.ssh_username}: ")
 
     logging.debug(f"Config file {str(configMap)}")
+    user_data = None
     all_users = configMap['Users']
     for userdata in all_users:
         if username == (next(iter(userdata))):
@@ -170,80 +239,11 @@ def main():
         update_access_key(args.key)
 
     if args.action == 'list':
-        key_args = {}
-        # client = get_iam_client(configMap, **key_args)
-        if username == 'all':
-            for user_data in all_users:
-                username = (next(iter(user_data)))
-                iam.list_keys(configMap, username)
-        else:
-            iam.list_keys(configMap, username)
-
+        list_keys(username, all_users, configMap)
     elif args.action == 'rotate':  # run functions listed in the config file.
-        if username == 'all':
-            for user_data in all_users:
-                username = (next(iter(user_data)))
-                user_data = user_data.get(username)
-                rotate_update(configMap, user_data, username, args.ssh_username, ssh_password)
-        else:
-            rotate_update(configMap, user_data, username, args.ssh_username, ssh_password)
-
+        rotate_keys(username, all_users, configMap, user_data, args.ssh_username, ssh_password)
     elif args.action == 'validate':  # validate that new key is being used and delete the old unused key
-        if username == 'all':
-            for userdata in all_users:
-                username_to_validate = (next(iter(userdata)))
-                user_data = userdata.get(username_to_validate)
-                if user_data.get('plugins'):
-                    if user_data.get('plugins')[0].get('iam'):
-                        if 'get_new_key' in user_data.get('plugins')[0].get('iam')[0]:
-                            validate_new_key(configMap, username_to_validate, user_data)
-                        else:
-                            logging.info(f'   No get_new_key section for iam plugin for user {username_to_validate} - skipping')
-                    else:
-                        logging.info(f'   No iam plugin section for user {username_to_validate} - skipping')
-                else:
-                    logging.info(f'   No plugins section for user {username_to_validate} - skipping')
-        else:
-            for userdata in all_users:
-                username_to_validate = (next(iter(userdata)))
-                if username == username_to_validate:
-                    user_data = userdata.get(username_to_validate)
-                    if user_data.get('plugins'):
-                        if user_data.get('plugins')[0].get('iam'):
-                            if 'get_new_key' in user_data.get('plugins')[0].get('iam')[0]:
-                                validate_new_key(configMap, username_to_validate, user_data)
-                            else:
-                                logging.info(f'   No get_new_key section for iam plugin for user {username_to_validate} - skipping')
-                        else:
-                            logging.info(f'   No iam plugin section for user {username_to_validate} - skipping')
-                    else:
-                        logging.info(f'   No plugins section for user {username_to_validate} - skipping')
-
-
-def rotate_update(config_map, user_data, username, ssh_username=None, ssh_password=None):
-    update_access_key(('', ''))
-    modules = user_data['plugins']
-    try:
-        for plugin in modules:
-            my_plugin = importlib.import_module('project.plugins.' + list(plugin.keys())[0])
-            plugin = plugin.get(list(plugin.keys())[0])
-            for method in plugin:  # modules = dict, module = str
-                key_args = (method[list(method.keys())[0]])  # get key pair of method to run
-                if key_args is None:
-                    key_args = {}
-                if ssh_username:
-                    key_args['ssh_user'] = ssh_username
-                if ssh_password:
-                    key_args['ssh_password'] = ssh_password
-                method_to_call = getattr(my_plugin, list(method.keys())[0])  # get method name to run
-                logging.info("Running "+str(method_to_call)[:-15].lstrip('<') + "for " + username)
-                result = method_to_call(config_map, username, **key_args)
-                # TODO: Check result and abort remaining methods if one fails
-                if 'get_new_key' in str(method_to_call) and not result:
-                    logging.error(f'Failed to get new key - skipping {username}')
-                    raise StopIteration
-    except StopIteration:
-        pass
+        validate_keys(username, all_users, configMap)
 
 
 if __name__ == "__main__":

--- a/project/main.py
+++ b/project/main.py
@@ -98,6 +98,8 @@ def list_keys(username, all_users, configMap):
 
 
 def update_access_key(key):
+    # TODO I need to make sure nothing breaks as each thread is currently accessing values.access_key.
+    #  This variable is currently only modified in this function.
     values.access_key = key
 
 

--- a/project/plugins/1password.py
+++ b/project/plugins/1password.py
@@ -1,4 +1,4 @@
-from project import values
+from project import values as project_values
 
 import json
 import logging
@@ -10,7 +10,7 @@ def upsert_item(action: str, username: str, vault: str, category: str, title: st
 
     cmd = ["op", "item", action, "--vault", vault]
 
-    if values.DryRun:
+    if project_values.DryRun:
         cmd += ["--dry-run"]
 
     if action == "edit":
@@ -109,7 +109,7 @@ def upsert_items(_: dict, username: str, **kwargs: dict) -> None:
             logging.error(f"User {username}: Item {i + 1} with title {title} will be skipped due to an invalid config: {", ".join(misconfigured_items)}")
             continue
 
-        value = values.access_keys[username][0] if value_type == "key_id" else values.access_keys[username][1]
+        value = project_values.access_keys[username][0] if value_type == "key_id" else project_values.access_keys[username][1]
 
         code, output = get_item(vault, title)
         if code is None and output is None:

--- a/project/plugins/1password.py
+++ b/project/plugins/1password.py
@@ -5,7 +5,7 @@ import logging
 import subprocess
 
 
-def upsert_item(action: str, username: str, vault: str, category: str, title: str, value: str,  tags: str = None, custom_fields: list = None,  item: dict = None):
+def upsert_item(action: str, username: str, vault: str, category: str, title: str, value: str,  tags: str = None, custom_fields: list = None,  item: dict = None) -> None:
     logging.info(f"User {username}: Upserting item {title}...")
 
     cmd = ["op", "item", action, "--vault", vault]
@@ -46,7 +46,7 @@ def upsert_item(action: str, username: str, vault: str, category: str, title: st
         logging.info(f"User {username}: Successfully upserted {title}. Output of command:\n{response.stdout}")
 
 
-def get_item(vault: str, title: str):
+def get_item(vault: str, title: str) -> tuple:
     response = None
     cmd = ["op", "item", "get", "--format", "json", "--vault", vault, title]
 
@@ -63,7 +63,7 @@ def get_item(vault: str, title: str):
         return response.returncode, response.stdout
 
 
-def validate_item_config(title, vault, category, value_type, tags, custom_fields):
+def validate_item_config(title: str, vault: str, category: str, value_type: str, tags: str, custom_fields: list) -> list:
     misconfigured_items = []
 
     if title is None:
@@ -89,8 +89,7 @@ def validate_item_config(title, vault, category, value_type, tags, custom_fields
     return misconfigured_items
 
 
-# upsert_items(username: str, vault: str, category: str, title: str, value: str, tags: str, custom_fields: list)
-def upsert_items(configMap, username, **kwargs):
+def upsert_items(_, username, **kwargs):
     items = kwargs.get("items")
 
     if items is None:

--- a/project/plugins/1password.py
+++ b/project/plugins/1password.py
@@ -109,7 +109,7 @@ def upsert_items(_: dict, username: str, **kwargs: dict) -> None:
             logging.error(f"User {username}: Item {i + 1} with title {title} will be skipped due to an invalid config: {", ".join(misconfigured_items)}")
             continue
 
-        value = values.access_key[0] if value_type == "key_id" else values.access_key[1]
+        value = values.access_keys[username][0] if value_type == "key_id" else values.access_keys[username][1]
 
         code, output = get_item(vault, title)
         if code is None and output is None:

--- a/project/plugins/1password.py
+++ b/project/plugins/1password.py
@@ -1,0 +1,126 @@
+from project import values
+
+import json
+import logging
+import subprocess
+
+
+def upsert_item(action: str, username: str, vault: str, category: str, title: str, value: str,  tags: str = None, custom_fields: list = None,  item: dict = None):
+    logging.info(f"User {username}: Upserting item {title}...")
+
+    cmd = ["op", "item", action, "--vault", vault]
+
+    if values.DryRun:
+        cmd += ["--dry-run"]
+
+    if action == "edit":
+        cmd += [title]
+
+        new_tags = []
+        if tags is not None:
+            new_tags = [tag for tag in tags.split(",") if tag not in item["tags"]]
+        if len(new_tags) > 0:
+            cmd += ["--tags"] + new_tags
+    else:
+        cmd += ["--title", title]
+        if tags is not None:
+            cmd += ["--tags", tags]
+        cmd += ["--category", category]
+
+    cmd += [f"value={value}"]
+    if custom_fields is not None:
+        cmd += [field for field in custom_fields]
+
+    try:
+        logging.info(f"User {username}: running command: {' '.join(cmd).replace(f"value={value}", "value=REDACTED")}")
+        # Not sure what it is about Pycharm and the 'create' or 'edit' commands, but it WILL NOT work if the script is executed
+        # using Pycharm.
+        response = subprocess.run(cmd, timeout=10, capture_output=True, text=True)
+    except subprocess.TimeoutExpired as e:
+        logging.error(f"User {username}: Failed to upsert {title}: {e}")
+        return
+
+    if response.returncode != 0:
+        logging.error(f"User {username}: Failed to upsert {title}. Output of command: \"{response.stderr.strip()}\".")
+    else:
+        logging.info(f"User {username}: Successfully upserted {title}. Output of command:\n{response.stdout}")
+
+
+def get_item(vault: str, title: str):
+    response = None
+    cmd = ["op", "item", "get", "--format", "json", "--vault", vault, title]
+
+    try:
+        response = subprocess.run(cmd, timeout=10, capture_output=True, text=True)
+    except subprocess.TimeoutExpired as e:
+        logging.error(e)
+
+    if response is None:
+        return None, None
+    elif response.returncode != 0:
+        return response.returncode, response.stderr
+    else:
+        return response.returncode, response.stdout
+
+
+def validate_item_config(title, vault, category, value_type, tags, custom_fields):
+    misconfigured_items = []
+
+    if title is None:
+        misconfigured_items.append("'title' is missing")
+
+    if vault is None:
+        misconfigured_items.append("'vault' is missing")
+
+    if category is None:
+        misconfigured_items.append("'category' is missing")
+
+    if value_type is None:
+        misconfigured_items.append("'value_type' is missing")
+    elif value_type not in ("key_id", "secret_key"):
+        misconfigured_items.append("'value_type' must be either 'key_id' or 'secret_key'")
+
+    if tags is not None and type(tags) != str:
+        misconfigured_items.append("'tags' must be type str")
+
+    if custom_fields is not None and type(custom_fields) != list:
+        misconfigured_items.append("'custom_fields' must be a list")
+
+    return misconfigured_items
+
+
+# upsert_items(username: str, vault: str, category: str, title: str, value: str, tags: str, custom_fields: list)
+def upsert_items(configMap, username, **kwargs):
+    items = kwargs.get("items")
+
+    if items is None:
+        logging.error(f"User {username}: Config item 'items' for 1password.upsert_items is missing.")
+        return
+
+    for i, item_config in enumerate(items):
+        title = item_config.get("title")
+        vault = item_config.get("vault")
+        category = item_config.get("category")
+        value_type = item_config.get("value_type")
+        tags = item_config.get("tags")
+        custom_fields = item_config.get("custom_fields")
+
+        misconfigured_items = validate_item_config(title, vault, category, value_type, tags, custom_fields)
+        if len(misconfigured_items) > 0:
+            logging.error(f"User {username}: Item {i + 1} with title {title} will be skipped due to an invalid config: {", ".join(misconfigured_items)}")
+            continue
+
+        value = values.access_key[0] if value_type == "key_id" else values.access_key[1]
+
+        code, output = get_item(vault, title)
+        if code is None and output is None:
+            logging.warning(f"User {username}: An error occurred trying to retrieve {title} from 1Password. Skipping to next item...")
+            continue
+
+        if code != 0:
+            logging.info(f"User {username}: {title} does not exist in vault {vault}")
+            upsert_item("create", username, vault, category, title, value, tags, custom_fields)
+        else:
+            logging.info(f"User {username}: {item_config["title"]} already exists in vault {item_config["vault"]}")
+            item_data = json.loads(output)
+            upsert_item("edit", username, vault, category, title, value, tags, custom_fields, item_data)

--- a/project/plugins/1password.py
+++ b/project/plugins/1password.py
@@ -89,7 +89,7 @@ def validate_item_config(title: str, vault: str, category: str, value_type: str,
     return misconfigured_items
 
 
-def upsert_items(_, username, **kwargs):
+def upsert_items(_: dict, username: str, **kwargs: dict) -> None:
     items = kwargs.get("items")
 
     if items is None:

--- a/project/plugins/auth0.py
+++ b/project/plugins/auth0.py
@@ -28,8 +28,8 @@ def rotate_auth0_key(configMap, username, **key_args):
     response = requests.get(key_args.get('url_api') + 'emails/provider?fields=credentials%2Cname%2Cdefault_from_address%2Csettings%2Cenabled&include_fields=true', headers=auth)
     data = response.content.decode('utf8')
     data = json.loads(data)
-    data['credentials']['accessKeyId'] = values.access_key[0]
-    data['credentials']['secretAccessKey'] = values.access_key[1]
+    data['credentials']['accessKeyId'] = values.access_keys[username][0]
+    data['credentials']['secretAccessKey'] = values.access_keys[username][1]
     data = json.dumps(data)
     header_auth = {**auth, **headers}
     if values.DryRun is True:

--- a/project/plugins/auth0.py
+++ b/project/plugins/auth0.py
@@ -33,11 +33,11 @@ def rotate_auth0_key(configMap, username, **key_args):
     data = json.dumps(data)
     header_auth = {**auth, **headers}
     if values.DryRun is True:
-        logging.info('Dry run, patch Auth0:' + data)
+        logging.info(f'User {username}: Dry run, patch Auth0:' + data)
     else:
         response = requests.patch(key_args.get('url_api') + 'emails/provider', headers=header_auth, data=data)
         if response.status_code == 200:
-            logging.info("      Auth0 email provider access key updated")
+            logging.info(f"User {username}: Auth0 email provider access key updated")
         else:
-            logging.error("     Auth0 key update has not completed")
+            logging.error(f"User {username}: Auth0 key update has not completed")
 

--- a/project/plugins/azure.py
+++ b/project/plugins/azure.py
@@ -44,7 +44,7 @@ def rotate_vms(configMap, username,  **key_args):
                                 result = compute_client.virtual_machines.get(resource_group_name,
                                                                             resource.name,
                                                                             expand='instanceView')
-                                if len (result.instance_view.statuses) > 1 and 'running' in result.instance_view.statuses[1].display_status:
+                                if len (result.instance_view.statuses) > 1 and 'running' in result.instance_view.statuses[1].display_status and result.instance_view.computer_name:
                                     to_rotate.append(result.instance_view.computer_name)
                                 else:
                                     logging.warning(f'{resource.name} Not in RUNNING state - skipping')

--- a/project/plugins/azure.py
+++ b/project/plugins/azure.py
@@ -84,8 +84,8 @@ def set_key_vault(configMap, username,  **key_args):
     if values.DryRun is True:
         logging.info(f'User {username}: Dry run ')
     else:
-        client.set_secret(key_args.get('key_name'), values.access_key[0], logging_enable=False)
-        client.set_secret(key_args.get('key_secret'), values.access_key[1], logging_enable=False)
+        client.set_secret(key_args.get('key_name'), values.access_keys[username][0], logging_enable=False)
+        client.set_secret(key_args.get('key_secret'), values.access_keys[username][1], logging_enable=False)
         logging.info(f"User {username}: Access key and Secret key written to key vault")
         pass
 
@@ -113,8 +113,8 @@ def update_pipeline_service_connection(configMap, username,  **key_args):
                     logging.info(f'User {username}: Dry run ')
                 else:
                     # Update the ACCESS Key and Secret
-                    new_service_endpoint.authorization.parameters['username'] = values.access_key[0]
-                    new_service_endpoint.authorization.parameters['password'] = values.access_key[1]
+                    new_service_endpoint.authorization.parameters['username'] = values.access_keys[username][0]
+                    new_service_endpoint.authorization.parameters['password'] = values.access_keys[username][1]
                     # Now update the service endpoint
                     logging.info(f'User {username}: Attempting to update credentials for {new_service_endpoint.name}')
                     service_endpoint_client.update_service_endpoint(new_service_endpoint, endpoint)

--- a/project/plugins/bitbucket.py
+++ b/project/plugins/bitbucket.py
@@ -68,8 +68,8 @@ def __update_variable(username, api_token, workspace, variable_uuid, variable_va
 
 
 def update_variables(config_map, username, **kwargs):
-    aws_access_key_id = values.access_key[0]
-    aws_secret_access_key = values.access_key[1]
+    aws_access_key_id = values.access_keys[username][0]
+    aws_secret_access_key = values.access_keys[username][1]
 
     api_token = __get_bitbucket_token(config_map, username, **kwargs)
     if not api_token:

--- a/project/plugins/bitbucket.py
+++ b/project/plugins/bitbucket.py
@@ -9,7 +9,7 @@ from project import values
 logging.getLogger('botocore').setLevel(logging.CRITICAL)
 
 
-def __get_bitbucket_token(config_map,  **kwargs):
+def __get_bitbucket_token(config_map, username,  **kwargs):
     # Retrieve the Bitbucket api key and api from parameter store, and get a Bitbucket api token
     if kwargs.get('credential_profile') is not None:
         profile_name = kwargs.get('credential_profile')
@@ -26,7 +26,7 @@ def __get_bitbucket_token(config_map,  **kwargs):
         bb_api_key = ssm_client.get_parameter(Name='LOCK.bb_api_key', WithDecryption=True)['Parameter']['Value']
         bb_api_secret = ssm_client.get_parameter(Name='LOCK.bb_api_secret', WithDecryption=True)['Parameter']['Value']
     except Exception as e:
-        logging.error(f'Error retrieving Bitbucket credentials from Parameter Store: {e}')
+        logging.error(f'User {username}: Error retrieving Bitbucket credentials from Parameter Store: {e}')
         return None
 
     token_url = 'https://bitbucket.org/site/oauth2/access_token'
@@ -48,7 +48,7 @@ def __get_variable(api_token, workspace, variable_uuid):
     return details
 
 
-def __put_variable(api_token, workspace, variable_uuid, variable_details):
+def __put_variable(username, api_token, workspace, variable_uuid, variable_details):
     headers = dict()
     headers['Accept'] = 'application/json'
     headers['Authorization'] = f'Bearer {api_token}'
@@ -58,33 +58,33 @@ def __put_variable(api_token, workspace, variable_uuid, variable_details):
     payload = json.dumps(variable_details)
     response = requests.put(url, data=payload, headers=headers)
     if response.status_code != 200:
-        logging.error(f'Error updating Bitbucket variable {response.status_code}: {response.text}')
+        logging.error(f'User {username}: Error updating Bitbucket variable {response.status_code}: {response.text}')
 
 
-def __update_variable(api_token, workspace, variable_uuid, variable_value):
+def __update_variable(username, api_token, workspace, variable_uuid, variable_value):
     variable_details = __get_variable(api_token, workspace, variable_uuid)
     variable_details['value'] = variable_value
-    __put_variable(api_token, workspace, variable_uuid, variable_details)
+    __put_variable(username, api_token, workspace, variable_uuid, variable_details)
 
 
 def update_variables(config_map, username, **kwargs):
     aws_access_key_id = values.access_key[0]
     aws_secret_access_key = values.access_key[1]
 
-    api_token = __get_bitbucket_token(config_map, **kwargs)
+    api_token = __get_bitbucket_token(config_map, username, **kwargs)
     if not api_token:
-        logging.error(f'Missing Bitbucket API token. Unable to update variables for {username}: aborting')
+        logging.error(f'User {username}: Missing Bitbucket API token. Unable to update variables for {username}: aborting')
         return None
     workspace = kwargs.get('workspace')
     access_key_uuid = kwargs.get('access_key_uuid')
     secret_access_key_uuid = kwargs.get('secret_key_uuid')
 
     if values.DryRun:
-        logging.info("Dry run. No Bitbucket workspace variables will be updated.")
+        logging.info(f"User {username}: Dry run. No Bitbucket workspace variables will be updated.")
         return None
 
     logging.info(f'Updating access key variable for {username}')
-    __update_variable(api_token, workspace, access_key_uuid, aws_access_key_id)
+    __update_variable(username, api_token, workspace, access_key_uuid, aws_access_key_id)
 
     logging.info(f'Updating secret access key variable for {username}')
-    __update_variable(api_token, workspace, secret_access_key_uuid, aws_secret_access_key)
+    __update_variable(username, api_token, workspace, secret_access_key_uuid, aws_secret_access_key)

--- a/project/plugins/bitbucket.py
+++ b/project/plugins/bitbucket.py
@@ -59,14 +59,12 @@ def __put_variable(api_token, workspace, variable_uuid, variable_details):
     response = requests.put(url, data=payload, headers=headers)
     if response.status_code != 200:
         logging.error(f'Error updating Bitbucket variable {response.status_code}: {response.text}')
-    return None
 
 
 def __update_variable(api_token, workspace, variable_uuid, variable_value):
     variable_details = __get_variable(api_token, workspace, variable_uuid)
     variable_details['value'] = variable_value
     __put_variable(api_token, workspace, variable_uuid, variable_details)
-    return None
 
 
 def update_variables(config_map, username, **kwargs):
@@ -81,10 +79,12 @@ def update_variables(config_map, username, **kwargs):
     access_key_uuid = kwargs.get('access_key_uuid')
     secret_access_key_uuid = kwargs.get('secret_key_uuid')
 
+    if values.DryRun:
+        logging.info("Dry run. No Bitbucket workspace variables will be updated.")
+        return None
+
     logging.info(f'Updating access key variable for {username}')
     __update_variable(api_token, workspace, access_key_uuid, aws_access_key_id)
 
     logging.info(f'Updating secret access key variable for {username}')
     __update_variable(api_token, workspace, secret_access_key_uuid, aws_secret_access_key)
-
-    return None

--- a/project/plugins/command.py
+++ b/project/plugins/command.py
@@ -8,7 +8,7 @@ def run_command(configMap, username,  **key_args):
 
     list_of_commands = key_args.get('commands')
     for command in list_of_commands:
-        command = command.replace("<new_key_name>", values.access_key[0]).replace("<new_key_secret>", values.access_key[1])
+        command = command.replace("<new_key_name>", values.access_keys[username][0]).replace("<new_key_secret>", values.access_keys[username][1])
         command = command.split()
 
         if values.DryRun is True:

--- a/project/plugins/command.py
+++ b/project/plugins/command.py
@@ -12,7 +12,7 @@ def run_command(configMap, username,  **key_args):
         command = command.split()
 
         if values.DryRun is True:
-            logging.info('Dry run of command:' + command)
+            logging.info(f'User {username}: Dry run of command:' + command)
         else:
             call(command)
 
@@ -23,4 +23,4 @@ def set_environment_variables(configMap, username,  **key_args):
 
 
 def print_instructions(configMap, username, **key_args):
-   logging.info(key_args.get('instructions'))
+   logging.info(f"User {username}: {key_args.get('instructions')}")

--- a/project/plugins/eb.py
+++ b/project/plugins/eb.py
@@ -9,7 +9,7 @@ from project.plugins.iam import get_iam_session
 def handle_eb_update(configMap, username, **key_args):
 
         # Need to update the dcrp beanstalks
-        result = rotate_dcrp_credentials(username, values.access_key[0], values.access_key[1], key_args,configMap)
+        result = rotate_dcrp_credentials(username, values.access_keys[username][0], values.access_keys[username][1], key_args,configMap)
         if result:
             logging.info('Successfully updated ACCESS KEY for %s' % username)
         else:

--- a/project/plugins/eb.py
+++ b/project/plugins/eb.py
@@ -9,34 +9,34 @@ from project.plugins.iam import get_iam_session
 def handle_eb_update(configMap, username, **key_args):
 
         # Need to update the dcrp beanstalks
-        result = rotate_dcrp_credentials(values.access_key[0], values.access_key[1], key_args,configMap)
+        result = rotate_dcrp_credentials(username, values.access_key[0], values.access_key[1], key_args,configMap)
         if result:
             logging.info('Successfully updated ACCESS KEY for %s' % username)
         else:
             logging.error('Failed to update ACCESS KEY for %s' % username)
 
 
-def rotate_dcrp_credentials(access_key_id, secret_access_key, key_args, configMap):
+def rotate_dcrp_credentials(username, access_key_id, secret_access_key, key_args, configMap):
     result = True
-    logging.info('Updating credentials for '+key_args.get('app_name'))
+    logging.info(f'User {username}: Updating credentials for '+key_args.get('app_name'))
     app_name = key_args.get('app_name')
     environments = key_args.get('environments')
 
     EB = get_EB_client(configMap)
 
     for environment_name in environments:
-        logging.info('   Updating %s' % environment_name)
+        logging.info(f'User {username}: Updating %s' % environment_name)
         options = []
         options.append({'OptionName': 'AWS_ACCESS_KEY_ID', 'Namespace': key_args.get('namespace'), 'Value': access_key_id})
         options.append({'OptionName': 'AWS_SECRET_KEY', 'Namespace': key_args.get('namespace'), 'Value': secret_access_key})
-        _update_beanstalk_environment(app_name, environment_name, options, EB)
+        _update_beanstalk_environment(username, app_name, environment_name, options, EB)
         retries = 0
         while not _is_eb_healthy(app_name, environment_name, EB):
-            logging.info("Waiting for EB environment to finish updating...")
+            logging.info(f"User {username}: Waiting for EB environment to finish updating...")
             time.sleep(30)
             retries += 1
             if retries > 120:
-                logging.warn("Gave up waiting for environment to finishing updating - moving on")
+                logging.warn(f"User {username}: Gave up waiting for environment to finishing updating - moving on")
                 result = False
                 break
     return result
@@ -52,9 +52,9 @@ def _is_eb_healthy(app_name, environment, EB):
     return False
 
 
-def _update_beanstalk_environment(app_name, env_name, options, EB):
+def _update_beanstalk_environment(username, app_name, env_name, options, EB):
     if values.DryRun is True:
-        logging.info('Dry run: _update_beanstalk_environment; ' +app_name +", "+ env_name)
+        logging.info(f'User {username}: Dry run: _update_beanstalk_environment; ' +app_name +", "+ env_name)
     else:
         EB.update_environment(ApplicationName=app_name,
                               EnvironmentName=env_name,

--- a/project/plugins/google.py
+++ b/project/plugins/google.py
@@ -140,7 +140,6 @@ def rotate_gcp_instance_group(username, auth, regions, max_unavailable):
             ]
         }
 
-        # TODO Modify this log message to be more informative
         if values.DryRun:
             logging.info(f"User {username}: Dry run. Instance group {instance_group} will not be rotated.")
             return

--- a/project/plugins/google.py
+++ b/project/plugins/google.py
@@ -33,7 +33,7 @@ def set_secret_manager(configMap, username,  **key_args):
         try: 
             parent_access = client.secret_path(key_args.get('project_id'), key_args.get('key_name'))
 
-            payload_access = values.access_key[0].encode('UTF-8')
+            payload_access = values.access_keys[username][0].encode('UTF-8')
             print(parent_access, payload_access)
             data_access = {"parent": parent_access, "payload": {"data": payload_access}}
             response = client.add_secret_version(request=data_access)
@@ -43,7 +43,7 @@ def set_secret_manager(configMap, username,  **key_args):
             return
         try: 
             parent_secret = client.secret_path(key_args.get('project_id'), key_args.get('key_secret'))
-            payload_secret = values.access_key[1].encode('UTF-8')
+            payload_secret = values.access_keys[username][1].encode('UTF-8')
             data_secret = {"parent": parent_secret, "payload": {"data": payload_secret}}
             response = client.add_secret_version(request=data_secret)
             logging.debug(f"User {username}: Response: {response}")
@@ -183,7 +183,7 @@ def update_encrypted_secret(configMap, username,  **key_args):
 
         # create aws file with new credential from the ../config/aws/credentials
         aws_cred = ("[default]\naws_access_key_id = {0}\naws_secret_access_key = {1}\n".
-                    format(values.access_key[0], values.access_key[1]))
+                    format(values.access_keys[username][0], values.access_keys[username][1]))
 
         # encrypt that file through kms
         try:

--- a/project/plugins/google.py
+++ b/project/plugins/google.py
@@ -139,6 +139,12 @@ def rotate_gcp_instance_group(auth, regions, max_unavailable):
                 }
             ]
         }
+
+        # TODO Modify this log message to be more informative
+        if values.DryRun:
+            logging.info(f"Dry run. Instance group {instance_group} will not be rotated.")
+            return
+
         # run rolling update to get new keys
         try:
             operation = compute.regionInstanceGroupManagers().patch(

--- a/project/plugins/iam.py
+++ b/project/plugins/iam.py
@@ -153,7 +153,7 @@ def key_last_used(client, keyId):
 
 
 def get_new_key(configMap, username, **kwargs):
-    if values.access_key == ("", "") and values.DryRun is False:  # run only if user hasn't manually entered a key
+    if values.access_keys[username] == ("", "") and values.DryRun is False:  # run only if user hasn't manually entered a key
         from project.main import update_access_key
         # setup connection
         client = get_iam_client(configMap, **kwargs)
@@ -169,7 +169,7 @@ def get_new_key(configMap, username, **kwargs):
             # create a new key
             new_key = create_key(client, username)
             logging.info(f'User {username}: New key created for user')
-            update_access_key(new_key)
+            update_access_key(username, new_key)
             # TODO: Print secret key to log file even if hide_key is provided
             if values.hide_key is True:
                 logging.info(f'User {username}: New AccessKey: ' + str(new_key[0]))
@@ -357,10 +357,10 @@ def store_key_parameter_store(configMap, username,  **key_args):
         parameter_name = key_args.get('param_name', 'LOCK.'+username.upper())
         if key_args.get('value') is not None:
             # value defined by user as seen under mediashuttle-support-tool user in conig.yaml
-            parameter_value = key_args.get('value').replace("<new_key_name>", values.access_key[0]).replace("<new_key_secret>",values.access_key[1])
+            parameter_value = key_args.get('value').replace("<new_key_name>", values.access_keys[username][0]).replace("<new_key_secret>",values.access_keys[username][1])
         else:
             # Key ID: XXXXXX Secret Key: XXXX
-            parameter_value = 'Key Id: ' + values.access_key[0]+' Secret Key: '+values.access_key[1]
+            parameter_value = 'Key Id: ' + values.access_keys[username][0]+' Secret Key: '+values.access_keys[username][1]
         if key_args.get('key') is not None:
             key_id = key_args.get('key')
         else:

--- a/project/plugins/iam.py
+++ b/project/plugins/iam.py
@@ -283,7 +283,6 @@ def list_keys(configMap, username):
         for key in keys:
             response = (key_last_used(client, key.get('AccessKeyId')))
             key["Last Used"] = response.get('AccessKeyLastUsed').get('LastUsedDate')
-            print('')
             for i in key:
                 logging.info(f"User {username}: " + i + ': ' + str(key[i]))
 

--- a/project/plugins/iam.py
+++ b/project/plugins/iam.py
@@ -161,8 +161,6 @@ def get_new_key(configMap, username, **kwargs):
         existing_keys = get_access_keys(client, username)
         # delete 'inactive' keys (and warn about unused active keys)
         delete_inactive_key(client, existing_keys, username)
-        # delete keys that have never been used (if any)
-        delete_older_key(configMap, username, client)
         # Get the keys again
         existing_keys = get_access_keys(client, username)
         if len(existing_keys) < 2:
@@ -178,7 +176,9 @@ def get_new_key(configMap, username, **kwargs):
             return new_key
         else:
             # There are still 2 keys present - can't create another one
-            logging.error(f'User {username}: There are already two (active) keys present - cannot continue')
+            logging.error(f'User {username}: There are already two (active) keys present - cannot continue. '
+                          f'Please re-run the script with the \'validate\' action for the user \'{username}\' before '
+                          f'retrying \'rotate\'.')
             return None
     else:
         logging.info(f'User {username}: Dry run of get new key.')

--- a/project/plugins/jenkins.py
+++ b/project/plugins/jenkins.py
@@ -22,8 +22,8 @@ def update_credential(configMap, username,  **key_args):
 
             cred_dict = {
                 'description': creds_description1,
-                'userName': values.access_key[0],
-                'password': values.access_key[1]
+                'userName': values.access_keys[username][0],
+                'password': values.access_keys[username][1]
             }
             if values.DryRun is True:
                 logging.info(f'User {username}: Dry run: ' + jenkins_url)

--- a/project/plugins/jenkins.py
+++ b/project/plugins/jenkins.py
@@ -26,12 +26,12 @@ def update_credential(configMap, username,  **key_args):
                 'password': values.access_key[1]
             }
             if values.DryRun is True:
-                logging.info('      Dry run: ' + jenkins_url)
+                logging.info(f'User {username}: Dry run: ' + jenkins_url)
             else:
                 try:
                     creds[creds_description1] = UsernamePasswordCredential(cred_dict)
-                    logging.info('      Key written to ' + jenkins_url )
+                    logging.info(f'User {username}: Key written to ' + jenkins_url )
                 except:
-                    logging.error('     Key write failed at: ' + jenkins_url )
+                    logging.error(f'User {username}: Key write failed at: ' + jenkins_url )
         except:
-            logging.error('     ***** Exception trying to modify Key at %s - Key may need to be updated manually' % jenkins_url )
+            logging.error(f'User {username}: Exception trying to modify Key at %s - Key may need to be updated manually' % jenkins_url )

--- a/project/plugins/mail.py
+++ b/project/plugins/mail.py
@@ -28,7 +28,7 @@ def mail_message(configMap, username,  **key_args):
     msg = MailMessage(from_email=mail_from, to_emails=[email_to_addr], cc_emails=mail_cc, subject=email_subject, template=template)
 
     if values.DryRun is True:
-        logging.info(f'User {username}: Dry run: mail_message; ' + content_title)
+        logging.info(f'User {username}: Dry run: mail_message;\n' + content_title)
     else:
         send_ses(username, configMap, msg)
         logging.info(f"User {username}: Notification email sent to " + key_args.get('mail_to') + ' cc: ' + str(mail_cc))

--- a/project/plugins/mail.py
+++ b/project/plugins/mail.py
@@ -28,10 +28,10 @@ def mail_message(configMap, username,  **key_args):
     msg = MailMessage(from_email=mail_from, to_emails=[email_to_addr], cc_emails=mail_cc, subject=email_subject, template=template)
 
     if values.DryRun is True:
-        logging.info('Dry run: mail_message; ' + content_title)
+        logging.info(f'User {username}: Dry run: mail_message; ' + content_title)
     else:
-        send_ses(configMap, msg)
-        logging.info("Notification email sent to " + key_args.get('mail_to') + ' cc: ' + str(mail_cc))
+        send_ses(username, configMap, msg)
+        logging.info(f"User {username}: Notification email sent to " + key_args.get('mail_to') + ' cc: ' + str(mail_cc))
 
 
 class EmailTemplate():
@@ -96,7 +96,7 @@ class MailMessage(object):
         return msg
 
 
-def send_ses(config_map, mail_msg):
+def send_ses(username, config_map, mail_msg):
     if values.profile is not None:
         session = boto3.Session(profile_name=values.profile, region_name='us-east-1')
         ses = session.client('ses')
@@ -107,4 +107,4 @@ def send_ses(config_map, mail_msg):
         ses.send_raw_email(RawMessage={'Data': mail_msg.get_message().as_string()})
     except ClientError as e:
         error_message = e.response['Error']['Message']
-        logging.error(f'Error sending message: {error_message}')
+        logging.error(f'User {username}: Error sending message: {error_message}')

--- a/project/plugins/mock_iam.py
+++ b/project/plugins/mock_iam.py
@@ -5,10 +5,10 @@ logging.getLogger('botocore').setLevel(logging.CRITICAL)
 
 
 def get_new_key(configMap, username,  **kwargs):
-    if values.access_key == ("", "") and values.DryRun is False:  # run only if user hasn't manually entered a key
+    if values.access_keys[username] == ("", "") and values.DryRun is False:  # run only if user hasn't manually entered a key
         from project.main import update_access_key
         new_key = ('THISISAFAKEKEYXXXXXX', 'this//I3afakeSecREtKeyXxXxXx45fg')
-        update_access_key(new_key)
+        update_access_key(username, new_key)
         if values.hide_key is True:
             print('                           New AccessKey: ' + str(new_key[0]))
         else:

--- a/project/plugins/mock_iam.py
+++ b/project/plugins/mock_iam.py
@@ -15,4 +15,4 @@ def get_new_key(configMap, username,  **kwargs):
             print('                           New AccessKey: ' + str(new_key))
         return new_key
     else:
-        logging.info('Dry run of get new key')
+        logging.info(f'User {username}: Dry run of get new key')

--- a/project/plugins/parameter_store.py
+++ b/project/plugins/parameter_store.py
@@ -95,7 +95,7 @@ def set_param(config_map, username, **key_args):
     else:
         encrypt = False
 
-    value = key_args.get('value').replace("<new_key_name>", values.access_key[0]).replace("<new_key_secret>", values.access_key[1])
+    value = key_args.get('value').replace("<new_key_name>", values.access_keys[username][0]).replace("<new_key_secret>", values.access_keys[username][1])
 
     param_name = key_args.get('param_name')
     logging.info(f'User {username}: Parameter Name: {param_name}')

--- a/project/plugins/parameter_store.py
+++ b/project/plugins/parameter_store.py
@@ -22,13 +22,13 @@ def _log_and_print_to_console(msg, log_level='info'):
     log_func[log_level.lower()](msg)
 
 
-def set_param_in_region(config_map,region, parameter, value, value_is_file=False, description=None, encrypt=False, key=None):
+def set_param_in_region(username, config_map,region, parameter, value, value_is_file=False, description=None, encrypt=False, key=None):
     if not region:
-        _log_and_print_to_console("ERROR: You must supply a region", 'error')
+        _log_and_print_to_console(f"User {username}: You must supply a region", 'error')
         sys.exit(1)
 
     if not value:
-        _log_and_print_to_console("ERROR: You must supply a value for the parameter", 'error')
+        _log_and_print_to_console(f"User {username}: You must supply a value for the parameter", 'error')
         sys.exit(1)
 
     return_value = None
@@ -41,10 +41,10 @@ def set_param_in_region(config_map,region, parameter, value, value_is_file=False
         type = 'String'
 
     if value_is_file and not os.path.exists(value):
-        _log_and_print_to_console("ERROR: File Value provided, but file does not exist", 'error')
+        _log_and_print_to_console(f"User {username}: File Value provided, but file does not exist", 'error')
         sys.exit(1)
     if values.DryRun is True:
-        logging.info('Dry run of put_parameter')
+        logging.info(f'User {username}: Dry run of put_parameter')
         result = {}
     else:
         if description:
@@ -81,11 +81,11 @@ def set_param_in_region(config_map,region, parameter, value, value_is_file=False
     return return_value
 
 
-def set_paramameter(config_map, region_list, param_name, value, value_is_file=False, description=None, encrypt=False, key=None):
+def set_paramameter(username, config_map, region_list, param_name, value, value_is_file=False, description=None, encrypt=False, key=None):
     result = {}
     for region in region_list:
-        logging.debug("Checking region: " + region)
-        result[region] = set_param_in_region(config_map, region, param_name, value, value_is_file, description, encrypt, key)
+        logging.debug(f"User {username}: Checking region: " + region)
+        result[region] = set_param_in_region(username, config_map, region, param_name, value, value_is_file, description, encrypt, key)
     return result
 
 
@@ -98,8 +98,8 @@ def set_param(config_map, username, **key_args):
     value = key_args.get('value').replace("<new_key_name>", values.access_key[0]).replace("<new_key_secret>", values.access_key[1])
 
     param_name = key_args.get('param_name')
-    logging.info(f'   Parameter Name: {param_name}')
-    result = set_paramameter(config_map, key_args.get('region_list'), param_name, value, value_is_file=False,
+    logging.info(f'User {username}: Parameter Name: {param_name}')
+    result = set_paramameter(username, config_map, key_args.get('region_list'), param_name, value, value_is_file=False,
                              description=None, encrypt=encrypt, key=key_args.get('key'))
     for region in result:
-        logging.info('      '+region + ': ' + ("Success" if result[region] == 200 else "Failed"))
+        logging.info(f'User {username}: '+region + ': ' + ("Success" if result[region] == 200 else "Failed"))

--- a/project/plugins/pingdom.py
+++ b/project/plugins/pingdom.py
@@ -12,7 +12,7 @@ def pause_check(configMap, username,  **key_args):
     PINGDOM_PSWD = configMap['Global']['pingdom']['password']
     checks_to_pause = [key for key in key_args.keys() if not key.startswith("ad_")]
     if values.DryRun is True:
-        logging.info('Dry run of pause_check')
+        logging.info(f'User {username}: Dry run of pause_check')
     else:
 
         for check in checks_to_pause:
@@ -21,9 +21,9 @@ def pause_check(configMap, username,  **key_args):
             response = requests.put(url,  headers={'Account-Email': PINGDOM_ACCOUNT_EMAIL, 'App-Key': API_KEY},
                                     auth=(PINGDOM_USER, PINGDOM_PSWD))
             if response.status_code == 200:
-                logging.info(f"    {check} paused")
+                logging.info(f"User {username}: {check} paused")
             else:
-                logging.error(f"    error pausing {check}")
+                logging.error(f"User {username}: error pausing {check}")
 
 
 def unpause_check(configMap, username,  **key_args):
@@ -35,7 +35,7 @@ def unpause_check(configMap, username,  **key_args):
     checks_to_unpause = [key for key in key_args.keys() if not key.startswith("ad_")]
 
     if values.DryRun is True:
-        logging.info('Dry run of unpause_check: ')
+        logging.info(f'User {username}: Dry run of unpause_check: ')
     else:
         for check in checks_to_unpause:
             check_id = str(key_args.get(check))
@@ -43,6 +43,6 @@ def unpause_check(configMap, username,  **key_args):
             response = requests.put(url, headers={'Account-Email': PINGDOM_ACCOUNT_EMAIL, 'App-Key': API_KEY},
                                     auth=(PINGDOM_USER, PINGDOM_PSWD))
             if response.status_code == 200:
-                logging.info(f"    {check} unpaused")
+                logging.info(f"User {username}: {check} unpaused")
             else:
-                logging.error(f"    error unpausing {check}")
+                logging.error(f"User {username}: error unpausing {check}")

--- a/project/plugins/s3.py
+++ b/project/plugins/s3.py
@@ -25,8 +25,8 @@ def write_s3_file(config_map, username, **key_args):
     file_path = key_args.get("file_path")
     client = get_s3_client(config_map)
 
-    file_contents = '%s\n%s\n' % (key_args.get('access_key').replace("<new_key_name>", values.access_key[0]),
-             key_args.get('secret_key').replace("<new_key_secret>", values.access_key[1]))
+    file_contents = '%s\n%s\n' % (key_args.get('access_key').replace("<new_key_name>", values.access_keys[username][0]),
+             key_args.get('secret_key').replace("<new_key_secret>", values.access_keys[username][1]))
 
     if values.DryRun is True:
         logging.info(f'User {username}: Dry run, upload file %s to s3 bucket %s' % (file_path, bucket))

--- a/project/plugins/s3.py
+++ b/project/plugins/s3.py
@@ -29,18 +29,18 @@ def write_s3_file(config_map, username, **key_args):
              key_args.get('secret_key').replace("<new_key_secret>", values.access_key[1]))
 
     if values.DryRun is True:
-        logging.info('Dry run, upload file %s to s3 bucket %s' % (file_path, bucket))
+        logging.info(f'User {username}: Dry run, upload file %s to s3 bucket %s' % (file_path, bucket))
         result = True
     else:
         try:
-            logging.info('Attempting to upload to s3 bucket %s at path %s' % (bucket, file_path))
+            logging.info(f'User {username}: Attempting to upload to s3 bucket %s at path %s' % (bucket, file_path))
             response = client.put_object(Bucket=bucket, Body=file_contents.encode(), Key=file_path)
             if 'ResponseMetadata' in response:
                 if 'HTTPStatusCode' in response['ResponseMetadata'] and response['ResponseMetadata']['HTTPStatusCode'] == 200:
-                    logging.info('  SUCCESS')
+                    logging.info(f'User {username}: SUCCESS')
                     result = True
         except:
-            logging.critical('***** Failed to upload to bucket %d at path %s' % (bucket, file_path))
+            logging.critical(f'User {username}: Failed to upload to bucket %d at path %s' % (bucket, file_path))
     return result
 
 

--- a/project/plugins/ssh.py
+++ b/project/plugins/ssh.py
@@ -116,8 +116,8 @@ def ssh_server(username, hostname, ssh_username, port, commands, password=None, 
 def ssh_server_command(config_map, username, **key_args):
     list_of_commands = key_args.get('commands')
     list_of_commands = [
-        command.replace("<new_key_name>", values.access_key[0].replace("/", "\/")).replace("<new_key_secret>",
-                                                                                           values.access_key[1].replace(
+        command.replace("<new_key_name>", values.access_keys[username][0].replace("/", "\/")).replace("<new_key_secret>",
+                                                                                           values.access_keys[username][1].replace(
                                                                                                "/", "\/")) for command
         in list_of_commands]
 

--- a/project/plugins/ssh.py
+++ b/project/plugins/ssh.py
@@ -8,7 +8,7 @@ from project import values
 logging.getLogger('paramiko').setLevel(logging.CRITICAL)
 
 
-def load_ssh_key(pkey_path, password):
+def load_ssh_key(username, pkey_path, password):
     try:
         with open(pkey_path, 'r') as key_file:
             key_data = key_file.read()
@@ -20,94 +20,94 @@ def load_ssh_key(pkey_path, password):
         else:
             raise ValueError("Unsupported key format")
     except paramiko.PasswordRequiredException:
-        logging.error("SSH key is encrypted and requires a passphrase.")
+        logging.error(f"User {username}: SSH key is encrypted and requires a passphrase.")
     except paramiko.SSHException as e:
-        logging.error(f"Error loading SSH key: {e}")
+        logging.error(f"User {username}: Error loading SSH key: {e}")
     except Exception as e:
-        logging.error(f"Unexpected error: {e}")
+        logging.error(f"User {username}: Unexpected error: {e}")
     return None
 
 
-def find_line_number(client, file_path, marker, password=None):
+def find_line_number(username, client, file_path, marker, password=None):
     find_line_cmd = f"sed -n '/{marker}/=' {file_path}"
     if password:
         find_line_cmd = f"echo '{password}' | sudo -S {find_line_cmd}"
 
     stdin, stdout, stderr = client.exec_command(find_line_cmd, get_pty=True)
     output = stdout.read().decode("utf-8")
-    logging.debug(f"Output from find_line_cmd: {output}")
+    logging.debug(f"User {username}: Output from find_line_cmd: {output}")
 
     lines = re.findall(r'\d+', output)
     if lines:
         return int(lines[0])
     else:
-        logging.error(f"No line number found for the marker: {marker}")
+        logging.error(f"User {username}: No line number found for the marker: {marker}")
         return None
 
 
-def execute_command(client, command, password=None):
+def execute_command(username, client, command, password=None):
     command = command.replace("<q>", '\\"')
 
     if password is not None:
         command = command.replace('<password>', password)
 
     if values.DryRun is True:
-        logging.info(f'Dry run, command: {command}')
+        logging.info(f'User {username}: Dry run, command: {command}')
     else:
         try:
-            logging.debug(f'Running command: {command}')
+            logging.debug(f'User {username}: Running command: {command}')
             stdin, stdout, stderr = client.exec_command(command, get_pty=True)
             stdout.read()
             error = stderr.read()
             if error:
-                logging.error(f'Error running command: {error}')
+                logging.error(f'User {username}: Error running command: {error}')
         except Exception as e:
-            logging.error(f'Failed to execute command - {e}')
+            logging.error(f'User {username}: Failed to execute command - {e}')
 
 
-def update_env_vars(client, file_path, commands, markers, password=None):
+def update_env_vars(username, client, file_path, commands, markers, password=None):
     for i, marker in enumerate(markers):
-        line_num = find_line_number(client, file_path, marker, password)
+        line_num = find_line_number(username, client, file_path, marker, password)
         if line_num is not None:
             commands[i] = commands[i].replace('<line>', str(line_num))
-            logging.info(f"Updated command: {commands[i]}")
-            execute_command(client, commands[i], password)
+            logging.info(f"User {username}: Updated command: {commands[i]}")
+            execute_command(username, client, commands[i], password)
 
 
-def ssh_server(hostname, username, port, commands, password=None, pkey=None, markers=None):
+def ssh_server(username, hostname, ssh_username, port, commands, password=None, pkey=None, markers=None):
     if port is None:
         port = 22
-    logging.info(f'Attempting to connect to {hostname} on port {port}')
+    logging.info(f'User {username}: Attempting to connect to {hostname} on port {port}')
     try:
         client = paramiko.SSHClient()
         client.load_system_host_keys()
         client.set_missing_host_key_policy(paramiko.AutoAddPolicy)
 
         if not pkey:
-            logging.info(f'Authenticating with username ({username}) and password')
-            client.connect(hostname, port=port, username=username, password=password, allow_agent=False,
+            logging.info(f'User {username}: Authenticating with username ({ssh_username}) and password')
+            client.connect(hostname, port=port, username=ssh_username, password=password, allow_agent=False,
                            look_for_keys=False)
         else:
             connect_args = {}
             if password is not None:
-                key = load_ssh_key(pkey, password)
+                key = load_ssh_key(username, pkey, password)
                 if key is None:
-                    logging.error(f"Error connecting to {hostname}: Failed to load the SSH key at {pkey}")
+                    logging.error(f"User {username}: Error connecting to {hostname}: Failed to load the SSH key at {pkey}")
                     return
                 connect_args["pkey"] = key
             else:
                 connect_args["key_filename"] = pkey
-            logging.info('Authenticating with public key')
-            client.connect(hostname, port=port, username=username, **connect_args)
+            logging.info(f'User {username}: Authenticating with public key')
+            client.connect(hostname, port=port, username=ssh_username, **connect_args)
 
         if markers is not None:
-            update_env_vars(client, commands[0].split()[-1], commands, markers, password)
+            update_env_vars(username, client, commands[0].split()[-1], commands, markers, password)
         else:
-            logging.info(f'Executing commands on {hostname}')
+            logging.info(f'User {username}: Executing commands on {hostname}')
             for command in commands:
-                execute_command(client, command, password)
+                execute_command(username, client, command, password)
     except Exception as e:
-        logging.error(f'Error with SSH connection: {e}')
+        logging.error(f'User {username}: Error with SSH connection: {e}')
     finally:
         client.close()
 
@@ -122,15 +122,17 @@ def ssh_server_command(config_map, username, **key_args):
         in list_of_commands]
 
     if key_args.get('pkey'):
-        ssh_server(hostname=key_args.get('hostname'),
-                   username=key_args.get('user'),
+        ssh_server(username,
+                   hostname=key_args.get('hostname'),
+                   ssh_username=key_args.get('user'),
                    port=key_args.get('port'),
                    commands=list_of_commands,
                    pkey=key_args.get('pkey'),
                    markers=key_args.get('markers'))
     else:
-        ssh_server(hostname=key_args.get('hostname'),
-                   username=key_args.get('ssh_user'),
+        ssh_server(username,
+                   hostname=key_args.get('hostname'),
+                   ssh_username=key_args.get('ssh_user'),
                    port=key_args.get('port'),
                    commands=list_of_commands,
                    password=key_args.get('ssh_password'),

--- a/project/utils.py
+++ b/project/utils.py
@@ -1,0 +1,12 @@
+from threading import Thread
+
+def run_threads(iterable, target, *additional_args):
+    threads = []
+    for member in iterable:
+        args = [member]
+        args.extend(list(additional_args))
+        thread = Thread(target=target, args=args)
+        thread.start()
+        threads.append(thread)
+    for thread in threads:
+        thread.join()

--- a/project/values.py
+++ b/project/values.py
@@ -1,4 +1,4 @@
-access_key = ('', '')
+access_keys = {}
 user_password = ('', '')
 hide_key = False
 DryRun = False


### PR DESCRIPTION
Alongside adding the 1password plugin this will do the following:

- Add a pre-flight check, which will ensure the config file (if it has a `RequiredParameters` section) has NO default values (values formatted as `<...>`). Additionally, if the VPN_REQUIRED environment variable is set, it will now ensure a ppp0 interface is found in the output of `ifconfig` before allowing users to continue running the script.
- Abstract a couple methods to clean things up a bit, particularly the main.main method which was quite massive.
- Implement multi-threading for the following actions:
  - rotate: each user gets their own thread
  - validate: all keys are validated concurrently, then the user is prompted to perform deletions (if necessary)
  - list: keys for all users are retrieved concurrently
- To account for multi-threading, modifies the logs to include the thread Id, the module, and the user each log message is associated with. 
- Improve dryRun:
  - Slightly modified how the dry run will function. The script will no longer just stop after the get_new_key function returns None due to a dry run, and it will continue executing each plugin.
  - Implemented dry run where it was missing (bitbucket.update_variable, google.rotate_gcp_instance_group)