### PR TITLE
Remove broken comma

### DIFF
--- a/project/plugins/ssh.py
+++ b/project/plugins/ssh.py
@@ -45,7 +45,12 @@ def find_line_number(username, client, file_path, marker, password=None, sudo_cm
     logging.debug(f'User {username}: find_line_cmd: {find_line_cmd}')
     stdin, stdout, stderr = client.exec_command(find_line_cmd, get_pty=True)
     output = stdout.read().decode("utf-8")
+    exit_code = stdout.channel.recv_exit_status()
     logging.debug(f"User {username}: Output from find_line_cmd: {output}")
+    
+    if exit_code != 0:
+        logging.error(f"User {username}: Command failed with exit code {exit_code}: {output.strip()}")
+        return None
 
     lines = re.findall(r"\d+", output)
     if lines:

--- a/project/plugins/ssh.py
+++ b/project/plugins/ssh.py
@@ -78,7 +78,7 @@ def update_env_vars(username, client, commands, markers, password=None):
         sudo_cmd = False
         if commands[i].startswith('sudo'):
             sudo_cmd = True
-        file_path = commands[i].split()[-1].rstrip('"'),
+        file_path = commands[i].split()[-1].rstrip('"')
         line_num = find_line_number(username, client, file_path, marker, password, sudo_cmd)
         if line_num is not None:
             commands[i] = commands[i].replace("<line>", str(line_num))


### PR DESCRIPTION
An extra comma resulted in file path being a tuple, the executed command would return something like this:

```
bash: -c: line 1: syntax error near unexpected token `('
bash: -c: line 1: `sed -n '/AWS_SECRET_ACCESS_KEY/=' ('/home/user/test',)'
```
And since this output had a number `1` in it, the lookup code thought things worked and assumed `1` was the line number. It would then try to execute commands with that:
```
sed -i '1s|.*|AWS_ACCESS_KEY_ID=bar|' /home/user/test
sed -i '1s|.*|AWS_SECRET_ACCESS_KEY=bar|' /home/user/test
```

Which naturally results in a broken file.